### PR TITLE
Initialize filtered task assignments list in chat screens

### DIFF
--- a/flutter_fe/lib/view/business_acc/chat_screen.dart
+++ b/flutter_fe/lib/view/business_acc/chat_screen.dart
@@ -78,6 +78,7 @@ class _ChatScreenState extends State<ChatScreen> {
       setState(() {
         taskAssignments = fetchedAssignments;
         _isLoading = false;
+        filteredTaskAssignments = fetchedAssignments; // Initialize filtered list
       });
     }
   }

--- a/flutter_fe/lib/view/service_acc/chat_screen.dart
+++ b/flutter_fe/lib/view/service_acc/chat_screen.dart
@@ -78,6 +78,7 @@ class _ChatScreenState extends State<ChatScreen> {
       setState(() {
         taskAssignments = fetchedAssignments;
         _isLoading = false;
+        filteredTaskAssignments = fetchedAssignments; // Initialize filtered list
       });
     }
   }


### PR DESCRIPTION
- In `business_acc/chat_screen.dart` and `service_acc/chat_screen.dart`, initialized `filteredTaskAssignments` with the fetched `taskAssignments` data.